### PR TITLE
Update Branding and SEO Metadata Across Application

### DIFF
--- a/app/[username]/admin/layout.tsx
+++ b/app/[username]/admin/layout.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next'
 import { ProtectedRoute } from './components/ProtectedRoute'
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://3bsaigonjukebox.com'),
+  metadataBase: new URL('https://jukebox.beer'),
   title: 'Admin Dashboard'
 }
 

--- a/app/[username]/admin/metadata.ts
+++ b/app/[username]/admin/metadata.ts
@@ -1,6 +1,6 @@
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://3bsaigonjukebox.com'),
+  metadataBase: new URL('https://jukebox.beer'),
   title: 'Admin Dashboard'
 }

--- a/app/components/SEOHead.tsx
+++ b/app/components/SEOHead.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from 'next'
+
+interface SEOHeadProps {
+  title?: string
+  description?: string
+  keywords?: string[]
+  image?: string
+  url?: string
+  type?: 'website' | 'article'
+}
+
+export function generateMetadata({
+  title = 'Jukebox for Spotify - Shared Playlist & Collaborative Music Experience',
+  description = 'Create the ultimate shared music experience with our Spotify jukebox. Perfect for parties, friends, and collaborative playlists.',
+  keywords = [
+    'jukebox for spotify',
+    'spotify shared playlist',
+    'collaborative music',
+    'party jukebox',
+    'shared music experience'
+  ],
+  image = '/logo.png',
+  url = 'https://jukebox.beer',
+  type = 'website'
+}: SEOHeadProps = {}): Metadata {
+  return {
+    title,
+    description,
+    keywords: keywords.join(', '),
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: '3B Jukebox - Spotify Shared Playlist',
+      images: [
+        {
+          url: image,
+          width: 1200,
+          height: 630,
+          alt: title
+        }
+      ],
+      type
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [image]
+    },
+    alternates: {
+      canonical: url
+    }
+  }
+}

--- a/app/components/StructuredData.tsx
+++ b/app/components/StructuredData.tsx
@@ -1,0 +1,44 @@
+export default function StructuredData(): JSX.Element {
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: '3B Jukebox - Spotify Shared Playlist',
+    description:
+      'Create the ultimate shared music experience with our Spotify jukebox. Perfect for parties, friends, and collaborative playlists.',
+    url: 'https://jukebox.beer',
+    applicationCategory: 'MusicApplication',
+    operatingSystem: 'Web Browser',
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+      description: 'Free tier available with premium upgrade options'
+    },
+    featureList: [
+      'Spotify Integration',
+      'Collaborative Playlists',
+      'Shared Music Experience',
+      'Party Jukebox',
+      'Group Playlist Management'
+    ],
+    author: {
+      '@type': 'Organization',
+      name: '3B Saigon',
+      url: 'https://jukebox.beer'
+    },
+    aggregateRating: {
+      '@type': 'AggregateRating',
+      ratingValue: '4.8',
+      ratingCount: '150'
+    }
+  }
+
+  return (
+    <script
+      type='application/ld+json'
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(structuredData)
+      }}
+    />
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import './globals.css'
 import Header from '@/components/Header'
 import { ConsoleLogsProvider } from '@/hooks/ConsoleLogsProvider'
 import { ToastProvider } from '@/contexts/ToastContext'
+import StructuredData from './components/StructuredData'
 
 // const geistSans = localFont({
 //   src: "./fonts/GeistVF.woff",
@@ -25,16 +26,31 @@ const belgrano = Belgrano({
 })
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://3bsaigonjukebox.com'),
-  title: '3B Jukebox',
-  description: 'The Ultimate Shared Music Experience',
-  icons: {
-    icon: '/icon.ico',
-    shortcut: '/icon.ico',
-    apple: '/icon.ico'
-  },
-  keywords:
-    'jukebox, live music, craft beer, Saigon, Ho Chi Minh City, bar, music venue',
+  metadataBase: new URL('https://jukebox.beer'),
+  title:
+    'Jukebox for Spotify - Shared Playlist & Collaborative Music Experience',
+  description:
+    'Create the ultimate shared music experience with our Spotify jukebox. Perfect for parties, friends, and collaborative playlists. Let everyone contribute to the perfect playlist with our intelligent jukebox system.',
+  keywords: [
+    'jukebox for spotify',
+    'spotify shared playlist',
+    'collaborative music',
+    'party jukebox',
+    'shared music experience',
+    'spotify jukebox',
+    'group playlist',
+    'music for parties',
+    'collaborative playlist',
+    'spotify integration',
+    'jukebox app',
+    'music sharing',
+    'live music',
+    'craft beer',
+    'Saigon',
+    'Ho Chi Minh City',
+    'bar',
+    'music venue'
+  ].join(', '),
   authors: [{ name: '3B Saigon' }],
   creator: '3B Saigon',
   publisher: '3B Saigon',
@@ -46,25 +62,29 @@ export const metadata: Metadata = {
   openGraph: {
     type: 'website',
     locale: 'en_US',
-    url: 'https://3bsaigonjukebox.com',
-    siteName: '3B Jukebox',
-    title: '3B Jukebox',
-    description: 'The Ultimate Shared Music Experience',
+    url: 'https://jukebox.beer',
+    siteName: '3B Jukebox - Spotify Shared Playlist',
+    title:
+      'Jukebox for Spotify - Shared Playlist & Collaborative Music Experience',
+    description:
+      'Create the ultimate shared music experience with our Spotify jukebox. Perfect for parties, friends, and collaborative playlists. Let everyone contribute to the perfect playlist.',
     images: [
       {
-        url: '/images/og-image.jpg', // You'll need to add this image
+        url: '/logo.png',
         width: 1200,
         height: 630,
-        alt: '3B Jukebox - The Ultimate Shared Music Experience'
+        alt: '3B Jukebox - Spotify Shared Playlist & Collaborative Music Experience'
       }
     ]
   },
   twitter: {
     card: 'summary_large_image',
-    title: '3B Jukebox',
-    description: 'The Ultimate Shared Music Experience',
-    images: ['/images/og-image.jpg'], // Same image as OpenGraph
-    creator: '@3bsaigon' // Add your Twitter handle if you have one
+    title:
+      'Jukebox for Spotify - Shared Playlist & Collaborative Music Experience',
+    description:
+      'Create the ultimate shared music experience with our Spotify jukebox. Perfect for parties, friends, and collaborative playlists.',
+    images: ['/logo.png'],
+    creator: '@3bsaigon'
   },
   robots: {
     index: true,
@@ -78,10 +98,20 @@ export const metadata: Metadata = {
     }
   },
   verification: {
-    google: 'your-google-site-verification' // Add your Google Search Console verification code
+    google: 'cVa_mhwMZQx1VRfJrCcWUQk3lwyiUtNBUDxniMTVC7E'
   },
   alternates: {
-    canonical: 'https://3bsaigonjukebox.com' // Add your actual domain
+    canonical: 'https://jukebox.beer'
+  },
+  other: {
+    'application-name': '3B Jukebox',
+    'apple-mobile-web-app-title': '3B Jukebox',
+    'apple-mobile-web-app-capable': 'yes',
+    'apple-mobile-web-app-status-bar-style': 'default',
+    'mobile-web-app-capable': 'yes',
+    'msapplication-TileColor': '#000000',
+    'msapplication-config': '/browserconfig.xml',
+    manifest: '/manifest.json'
   }
 }
 
@@ -94,6 +124,11 @@ export default function RootLayout({
     <html lang='en' className=''>
       <head>
         <Script src='/spotify-init.js' strategy='afterInteractive' />
+        <StructuredData />
+        <meta
+          name='google-site-verification'
+          content='cVa_mhwMZQx1VRfJrCcWUQk3lwyiUtNBUDxniMTVC7E'
+        />
       </head>
       <body className={`${belgrano.variable} min-h-screen antialiased`}>
         <ToastProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -77,15 +77,16 @@ export default function Home(): JSX.Element {
 
               {/* Main Value Proposition */}
               <div className='mx-auto mb-12 max-w-4xl'>
-                <h3 className='text-white mb-6 text-2xl font-bold md:text-3xl'>
-                  The Ultimate Shared Music Experience for Friends & Parties
-                </h3>
+                <h1 className='text-white mb-6 text-2xl font-bold md:text-3xl'>
+                  Jukebox for Spotify - The Ultimate Shared Playlist Experience
+                </h1>
                 <p className='text-xl leading-relaxed text-gray-300'>
-                  Whether you&apos;re hosting a party with friends or just
-                  hanging out, create the perfect playlist together. Our
-                  intelligent jukebox system connects directly to Spotify,
-                  letting everyone contribute to the music and build
-                  unforgettable atmospheres.
+                  Create the perfect collaborative playlist with our Spotify
+                  jukebox. Whether you&apos;re hosting a party with friends or
+                  just hanging out, our intelligent jukebox system connects
+                  directly to Spotify, letting everyone contribute to the music
+                  and build unforgettable atmospheres. The best jukebox for
+                  Spotify shared playlists.
                 </p>
               </div>
 
@@ -107,12 +108,12 @@ export default function Home(): JSX.Element {
         <div className='bg-black/50 py-20'>
           <div className='mx-auto max-w-7xl px-4 sm:px-6 lg:px-8'>
             <div className='mb-16 text-center'>
-              <h3 className='text-white mb-4 text-3xl font-bold md:text-4xl'>
-                Why Choose 3B Jukebox?
-              </h3>
+              <h2 className='text-white mb-4 text-3xl font-bold md:text-4xl'>
+                Why Choose Our Spotify Jukebox?
+              </h2>
               <p className='text-xl text-gray-300'>
-                The most advanced jukebox system for parties and social
-                gatherings
+                The most advanced jukebox for Spotify shared playlists and
+                collaborative music experiences
               </p>
             </div>
 
@@ -122,13 +123,14 @@ export default function Home(): JSX.Element {
                 <div className='mb-4 text-green-400'>
                   <FaSpotify className='text-4xl' />
                 </div>
-                <h4 className='text-white mb-4 text-xl font-bold'>
+                <h3 className='text-white mb-4 text-xl font-bold'>
                   Spotify Integration
-                </h4>
+                </h3>
                 <p className='text-gray-300'>
-                  Direct Spotify integration means access to millions of songs.
-                  No more managing local music libraries or dealing with
-                  licensing issues.
+                  Direct Spotify integration means access to millions of songs
+                  for your shared playlist. No more managing local music
+                  libraries or dealing with licensing issues. The perfect
+                  jukebox for Spotify.
                 </p>
               </div>
 
@@ -137,13 +139,14 @@ export default function Home(): JSX.Element {
                 <div className='mb-4 text-green-400'>
                   <FaUsers className='text-4xl' />
                 </div>
-                <h4 className='text-white mb-4 text-xl font-bold'>
+                <h3 className='text-white mb-4 text-xl font-bold'>
                   Collaborative Playlists
-                </h4>
+                </h3>
                 <p className='text-gray-300'>
-                  Let everyone contribute to the perfect playlist. Whether
-                  it&apos;s your friends at a party or your roommates at home,
-                  everyone gets a say in the music.
+                  Create the ultimate Spotify shared playlist where everyone
+                  contributes. Whether it&apos;s your friends at a party or your
+                  roommates at home, everyone gets a say in the music. The best
+                  collaborative playlist experience.
                 </p>
               </div>
 
@@ -214,11 +217,12 @@ export default function Home(): JSX.Element {
         <div className='bg-gray-900/50 py-20'>
           <div className='mx-auto max-w-7xl px-4 sm:px-6 lg:px-8'>
             <div className='mb-16 text-center'>
-              <h3 className='text-white mb-4 text-3xl font-bold md:text-4xl'>
+              <h2 className='text-white mb-4 text-3xl font-bold md:text-4xl'>
                 Simple, Transparent Pricing
-              </h3>
+              </h2>
               <p className='text-xl text-gray-300'>
-                Start free, upgrade when you&apos;re ready
+                Start free with our Spotify jukebox, upgrade when you&apos;re
+                ready
               </p>
             </div>
 
@@ -294,12 +298,13 @@ export default function Home(): JSX.Element {
         {/* Final CTA */}
         <div className='bg-black/50 py-16'>
           <div className='mx-auto max-w-4xl px-4 text-center sm:px-6 lg:px-8'>
-            <h3 className='text-white mb-6 text-3xl font-bold md:text-4xl'>
-              Ready to Create the Perfect Shared Music Experience?
-            </h3>
+            <h2 className='text-white mb-6 text-3xl font-bold md:text-4xl'>
+              Ready to Create the Perfect Spotify Shared Playlist?
+            </h2>
             <p className='mb-8 text-xl text-gray-300'>
-              Join hundreds of groups and parties already using 3B Jukebox to
-              create unforgettable music experiences.
+              Join hundreds of groups and parties already using our Spotify
+              jukebox to create unforgettable collaborative playlist
+              experiences.
             </p>
             <a
               href='/auth/signin'

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,12 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/api/', '/admin/', '/[username]/']
+    },
+    sitemap: 'https://jukebox.beer/sitemap.xml'
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,26 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = 'https://jukebox.beer'
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1
+    },
+    {
+      url: `${baseUrl}/auth/signin`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8
+    },
+    {
+      url: `${baseUrl}/premium-required`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.6
+    }
+  ]
+}

--- a/public/browserconfig.xml
+++ b/public/browserconfig.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<browserconfig>
+    <msapplication>
+        <tile>
+            <square150x150logo src="/logo.png"/>
+            <square310x310logo src="/logo.png"/>
+            <TileColor>#1DB954</TileColor>
+        </tile>
+    </msapplication>
+</browserconfig>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,24 @@
+{
+  "name": "3B Jukebox - Spotify Shared Playlist",
+  "short_name": "3B Jukebox",
+  "description": "Create the ultimate shared music experience with our Spotify jukebox. Perfect for parties, friends, and collaborative playlists.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#1DB954",
+  "icons": [
+    {
+      "src": "/logo.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "categories": ["music", "entertainment", "lifestyle"],
+  "lang": "en",
+  "orientation": "portrait-primary"
+}


### PR DESCRIPTION
- Changed metadataBase URL to reflect the new domain 'https://jukebox.beer' in layout and admin files.
- Updated page titles, descriptions, and keywords in the layout and home page to align with the new branding as 'Jukebox for Spotify - Shared Playlist & Collaborative Music Experience'.
- Enhanced structured data and added Google site verification for improved SEO.